### PR TITLE
fix running validate with -v

### DIFF
--- a/hooks/validate.sh
+++ b/hooks/validate.sh
@@ -43,7 +43,7 @@ if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
 
 declare -i MINVERSION=$TIMESTAMPING_VERSION
 
-while [[ $# -gt 1 ]]; do
+while [[ $# -gt 0 ]]; do
   KEY="$1"
 
   case $KEY in
@@ -66,12 +66,12 @@ while [[ $# -gt 1 ]]; do
       shift # past argument
       ;;
     *) # unknown option
-      echo_error "Unknown argument: $KEY"
-      exit 1
+      OBJECT=$KEY
+      shift # past argument
       ;;
   esac
 done
-OBJECT="$1"
+
 if [ -z "$OBJECT" ]; then
   OBJECT="HEAD"
 fi


### PR DESCRIPTION
accept any key except of `-v` and `-min` as `$OBJECT`

this fixes #5