### PR TITLE
fix comparison

### DIFF
--- a/hooks/validate.sh
+++ b/hooks/validate.sh
@@ -309,7 +309,7 @@ validate_commit_and_parents() {
       fi
     done <<< $(printf "%s" "$PARENTS")
   fi
-  if [ "$ALL_PASSED"=true ]; then
+  if [ "$ALL_PASSED" = true ]; then
     return 0
   fi
   return 1


### PR DESCRIPTION
You need spaces around the comparison operator.

See https://github.com/koalaman/shellcheck/wiki/SC2077

fixes #7 